### PR TITLE
Better username detection in get_user_obj

### DIFF
--- a/pycognito/__init__.py
+++ b/pycognito/__init__.py
@@ -350,6 +350,13 @@ class Cognito:
         what we'd like to display to the users
         :return: dictionary of the Cognito user response
         """
+        # try to detect the username from self or the attribute list if not set
+        if username is None:
+            if attribute_list is None:
+                username = self.username
+            else:
+                username = self.username or attribute_list.get("Username")
+
         return self.user_class(
             username=username,
             attribute_list=attribute_list,


### PR DESCRIPTION
Username property wasn't set in UserObj if Cognito wasn't instantiated with a username. However, it can be obtained from the access token.