### PR TITLE
Added admin_set_user_password

### DIFF
--- a/pycognito/__init__.py
+++ b/pycognito/__init__.py
@@ -750,6 +750,23 @@ class Cognito:
         response.pop("ResponseMetadata")
         return response
 
+    def admin_set_user_password(self, username, passqord, permanent=False):
+        """
+        Explicitly set a users password and optionaly set their status as
+        'Confirmed' when Permanent=True
+        :param username: the cognito username
+        :param passqord: the password to set for the user
+        :param permanent: set the password type -
+        if True user status will be set to 'Confirmed',
+        if False user status will be set to 'FORCE_CHANGE_PASSWORD'
+        """
+        self.client.admin_set_user_password(
+            UserPoolId=self.user_pool_id,
+            Username=username,
+            Password=passqord,
+            Permanent=permanent,
+        )
+
     def send_verification(self, attribute="email"):
         """
         Sends the user an attribute verification code for the specified attribute name.


### PR DESCRIPTION
Allows setting user password and updating user status. 
This enables users stuck in ‘FORCE_CHANGE_PASSWORD’ state to be set as ‘Confirmed’